### PR TITLE
Implement workflow history

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@ Appropriate documentation will come with version 1.0.0.
 
 ## Roadmap
 - Handle permissions (currently, any user can trigger a deployment)
-- Show history of deployments / workflows triggered
-- Filter deployment history by `environment`
+- Show history of deployments / workflows triggered ✅
+- Filter deployment history by `environment` ✅
 - **Optional:** Implement toasts for user feedback (although alerts are kinda nice because they force you to read and click to dismiss them)
 - Generalize the `environment` parameter to an `inputs` array and allow users to configure whether they want to filter deployment history by any of them
 - Documentation + Release 1.0.0 + Submit plugin to Strapi Market
 
 ### Possible further enhancements
 - Confirmation pop-up before triggering deployment
-- Automatic refresh of the history of deployments after trigger
+- Automatic refresh of the history of deployments after trigger ✅
 - Show workflow logs
 - Allow multiple workflows
 

--- a/admin/src/pages/HomePage.tsx
+++ b/admin/src/pages/HomePage.tsx
@@ -1,21 +1,40 @@
-import { Main, Typography, Button, Flex, Box } from '@strapi/design-system';
+import { Main, Typography, Button, Flex, Badge, Table, Thead, Tbody, Tr, Th, Td } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 import { getTranslation } from '../utils/getTranslation';
-import { Play } from '@strapi/icons';
-import { useState } from 'react';
+import { Play, ArrowClockwise } from '@strapi/icons';
+import { useEffect, useState } from 'react';
 import { useFetchClient } from '@strapi/strapi/admin';
 import { PLUGIN_ID } from '../pluginId';
+import { differenceInMilliseconds, formatRelative } from 'date-fns';
 
 const HomePage = () => {
   const { formatMessage } = useIntl();
-  const { post } = useFetchClient();
+  const { get, post } = useFetchClient();
   const [loadingTriggerButton, setLoadingTriggerButton] = useState(false);
+  const [history, setHistory] = useState([]);
+  const [loadingHistory, setLoadingHistory] = useState<'loading' | 'planned' | 'none'>('none');
+
+  async function fetchHistory() {
+    setLoadingHistory('loading');
+
+    try {
+      const { data } = await get(`/${PLUGIN_ID}/history`);
+      setHistory(data.workflow_runs.slice(0, 10));
+    } catch (error: any) {
+      console.error(error);
+      window.alert('Failed to fetch workflow history!'); // TODO: Implement toasts
+    } finally {
+      setLoadingHistory('none');
+    }
+  }
 
   async function triggerGithubActions() {
     try {
       setLoadingTriggerButton(true);
       await post(`/${PLUGIN_ID}/trigger`);
-      window.alert('Successfully started workflow!'); // TODO: Implement toasts
+      window.alert('Successfully started workflow!\n\nHistory will be refetched in 5 seconds'); // TODO: Implement toasts
+      setLoadingHistory('planned');
+      setTimeout(fetchHistory, 5000);
     } catch (error: any) {
       console.error(error);
       const { status, name } = error.response.data.error;
@@ -36,6 +55,10 @@ const HomePage = () => {
     }
   }
 
+  useEffect(() => {
+    fetchHistory();
+  }, []);
+
   // TODO: Wrap in <CheckPagePermissions />
   return (
     <Main
@@ -43,13 +66,73 @@ const HomePage = () => {
         padding: '3.2rem 5.4rem',
       }}
     >
-      <Flex direction="row" alignItems="center" justifyContent="space-between">
+      <Flex direction="row" alignItems="center" justifyContent="space-between" marginBottom='4rem'>
         <Typography variant='alpha'>{formatMessage({ id: getTranslation('plugin.name') })}</Typography>
 
-        <Button onClick={triggerGithubActions} loading={loadingTriggerButton} style={{ height: '4.2rem' }} variant='default' startIcon={<Play/>}>
-          <Typography fontSize="1.6rem">{formatMessage({ id: getTranslation('trigger-button.label') })}</Typography>
-        </Button>
+        <Flex direction="row" alignItems="center" gap='1rem'>
+          <Button onClick={fetchHistory} loading={loadingHistory !== 'none'} disabled={loadingTriggerButton} style={{ height: '4.2rem' }} variant='secondary' startIcon={<ArrowClockwise/>}>
+            <Typography fontSize="1.6rem">{formatMessage({ id: getTranslation('reload-button.label') })}</Typography>
+          </Button>
+          <Button onClick={triggerGithubActions} loading={loadingTriggerButton} disabled={loadingHistory !== 'none'} style={{ height: '4.2rem' }} variant='default' startIcon={<Play/>}>
+            <Typography fontSize="1.6rem">{formatMessage({ id: getTranslation('trigger-button.label') })}</Typography>
+          </Button>
+        </Flex>
       </Flex>
+
+      <Table colCount={5} rowCount={11}>
+        <Thead>
+          <Tr>
+            <Th key={'run-number'}><Typography variant='sigma'>{formatMessage({ id: getTranslation('history-table.run-number') })}</Typography></Th>
+            <Th key={'workflow-name'}><Typography variant='sigma'>{formatMessage({ id: getTranslation('history-table.workflow-name') })}</Typography></Th>
+            <Th key={'status'}><Typography variant='sigma'>{formatMessage({ id: getTranslation('history-table.status') })}</Typography></Th>
+            <Th key={'creation-date'}><Typography variant='sigma'>{formatMessage({ id: getTranslation('history-table.creation-date') })}</Typography></Th>
+            <Th key={'duration'}><Typography variant='sigma'>{formatMessage({ id: getTranslation('history-table.duration') })}</Typography></Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {loadingHistory === 'loading' && (
+            <Tr>
+              <Td></Td>
+              <Td></Td>
+              <Td><Typography variant='sigma'>Loading history...</Typography></Td>
+              <Td></Td>
+              <Td></Td>
+            </Tr>
+          )}
+          
+          {loadingHistory === 'planned' && (
+            <Tr>
+              <Td></Td>
+              <Td></Td>
+              <Td><Typography variant='sigma'>Loading history in 5 seconds...</Typography></Td>
+              <Td></Td>
+              <Td></Td>
+            </Tr>
+          )}
+
+          {loadingHistory === 'none' && (
+            history.map((workflow: any) => {
+              const msDuration = differenceInMilliseconds(new Date(workflow.updated_at), new Date(workflow.run_started_at));
+              const secs = (msDuration / 1000) % 60;
+              const mins = Math.floor(msDuration / 1000 / 60);
+              const relativeDate = formatRelative(new Date(workflow.created_at), new Date());
+              const year = relativeDate.includes('/') ? relativeDate.split('/')[2] : null;
+              const month = relativeDate.includes('/') ? relativeDate.split('/')[0] : null;
+              const day = relativeDate.includes('/') ? relativeDate.split('/')[1] : null;
+              const ymdRelativeDate = relativeDate.includes('/') ? `${year}-${month}-${day}` : relativeDate;
+
+              return (
+              <Tr key={workflow.id}>
+                <Td><Typography variant='sigma'>{workflow.run_number}</Typography></Td>
+                <Td><Typography variant='sigma'>{workflow.name}</Typography></Td>
+                <Td><Badge>{workflow.conclusion ?? workflow.status}</Badge></Td>
+                <Td><Typography variant='sigma'>{ymdRelativeDate}</Typography></Td>
+                <Td><Typography variant='sigma'>{workflow.conclusion ? `${mins}m ${secs}s` : 'in progress'}</Typography></Td>
+              </Tr>
+            )})
+          )}
+        </Tbody>
+      </Table>
     </Main>
   );
 };

--- a/admin/src/translations/en.json
+++ b/admin/src/translations/en.json
@@ -1,4 +1,10 @@
 {
   "static-deploy.plugin.name": "Deploy Static Site",
-  "static-deploy.trigger-button.label": "Trigger"
+  "static-deploy.trigger-button.label": "Trigger",
+  "static-deploy.reload-button.label": "Reload History",
+  "static-deploy.history-table.run-number": "RUN NUMBER",
+  "static-deploy.history-table.workflow-name": "WORKFLOW NAME",
+  "static-deploy.history-table.status": "STATUS",
+  "static-deploy.history-table.creation-date": "CREATION DATE",
+  "static-deploy.history-table.duration": "DURATION"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-static-deploy",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Trigger Github workflows to build and deploy statically generated websites",
   "license": "MIT",
   "strapi": {
@@ -51,27 +51,28 @@
   "dependencies": {
     "@strapi/design-system": "^2.0.0-rc.14",
     "@strapi/icons": "^2.0.0-rc.14",
+    "date-fns": "^4.1.0",
     "react-intl": "^7.1.0"
   },
   "peerDependencies": {
-    "@strapi/strapi": "^5.6.0",
     "@strapi/sdk-plugin": "^5.3.0",
+    "@strapi/strapi": "^5.6.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.28.1",
     "styled-components": "^6.1.14"
   },
   "devDependencies": {
-    "@strapi/strapi": "^5.6.0",
     "@strapi/sdk-plugin": "^5.3.0",
+    "@strapi/strapi": "^5.6.0",
+    "@strapi/typescript-utils": "^5.6.0",
+    "@types/react": "^19.0.3",
+    "@types/react-dom": "^19.0.2",
     "prettier": "^3.4.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.28.1",
     "styled-components": "^6.1.14",
-    "@types/react": "^19.0.3",
-    "@types/react-dom": "^19.0.2",
-    "@strapi/typescript-utils": "^5.6.0",
     "typescript": "^5.7.2"
   },
   "repository": {

--- a/server/src/controllers/githubActions.ts
+++ b/server/src/controllers/githubActions.ts
@@ -1,6 +1,10 @@
 import { PLUGIN_ID } from '../../../admin/src/pluginId';
 
 const githubActionsController = {
+  async history(ctx: any) {
+    const response = await strapi.plugin(PLUGIN_ID).service('githubActions').history();
+    ctx.send(response.data);
+  },
   async trigger(ctx: any) {
     const response = await strapi.plugin(PLUGIN_ID).service('githubActions').trigger();
     if (response.status === 422 && response.statusText == 'Unprocessable Entity') {

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -2,6 +2,17 @@ export default {
   type: 'admin',
   routes: [
     {
+      method: 'GET',
+      path: '/history',
+      handler: 'githubActions.history',
+      config: {
+        policies: [
+          'admin::isAuthenticatedAdmin',
+          // TODO: Add policy to make sure admin user has permissions
+        ],
+      },
+    },
+    {
       method: 'POST',
       path: '/trigger',
       handler: 'githubActions.trigger',

--- a/server/src/services/githubActions.ts
+++ b/server/src/services/githubActions.ts
@@ -28,6 +28,56 @@ const githubActionsService = ({ strapi }: { strapi: Core.Strapi }) => ({
       } catch (err: any) {
         return err.response;
       }
+    },
+    async history() {
+      try {
+        const owner = strapi.plugin(PLUGIN_ID).config('owner');
+        const repo = strapi.plugin(PLUGIN_ID).config('repo');
+        const workflowID = strapi.plugin(PLUGIN_ID).config('workflowID');
+        const branch = strapi.plugin(PLUGIN_ID).config('branch');
+        const githubToken = strapi.plugin(PLUGIN_ID).config('githubToken');
+        const environment = strapi.plugin(PLUGIN_ID).config('environment'); // TODO: Generalize this to inputs to be able to add any input
+
+        const history = await axios.get(
+          `https://api.github.com/repos/${owner}/${repo}/actions/workflows/${workflowID}/runs?branch=${branch}&per_page=100&page=1`,
+          {
+            headers: {
+              Accept: 'application/vnd.github+json',
+              Authorization: `token ${githubToken}`,
+            },
+          }
+        );
+
+        // The following is an array of bools that maps whether or not each workflow belongs to the current environment
+        const environmentHistory: ReadonlyArray<boolean> = await Promise.all(
+          history.data.workflow_runs.map(
+            async (workflow: { readonly jobs_url: string }) => {
+              const jobs = await axios.get(workflow.jobs_url, {
+                headers: {
+                  Accept: 'application/vnd.github+json',
+                  Authorization: `token ${githubToken}`,
+                },
+              });
+
+              return (
+                jobs.data.jobs.find((job: { readonly name: string }) =>
+                  job.name.includes(environment as string)
+                ) !== undefined
+              );
+            }
+          )
+        );
+
+        return {
+          data: {
+            workflow_runs: history.data.workflow_runs.filter(
+              (_: object, index: number) => environmentHistory[index]
+            ),
+          },
+        };
+      } catch (err: any) {
+        return err.response;
+      }
     }
 })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4382,6 +4382,11 @@ date-fns@2.30.0, date-fns@^2.30.0:
   dependencies:
     "@babel/runtime" "^7.21.0"
 
+date-fns@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.1.0.tgz#64b3d83fff5aa80438f5b1a633c2e83b8a1c2d14"
+  integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
+
 debounce@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"


### PR DESCRIPTION
Added features:
- Plugin page now shows the latest 10 workflows ran (showing run number, workflow name, status, creation date and duration)
- Fetched workflows are filtered by the `environment` input
- Add automatic refetch of workflow history after trigger (with 5 second delay)
- Add button to manually refetch workflow history