### PR TITLE
Substitute standard alerts with Strapi notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Appropriate documentation will come with version 1.0.0.
 - Handle permissions (currently, any user can trigger a deployment) ✅
 - Show history of deployments / workflows triggered ✅
 - Filter deployment history by `environment` ✅
-- **Optional:** Implement toasts for user feedback (although alerts are kinda nice because they force you to read and click to dismiss them)
+- **Optional:** Implement toasts for user feedback (although alerts are kinda nice because they force you to read and click to dismiss them) ✅
 - Generalize the `environment` parameter to an `inputs` array and allow users to configure whether they want to filter deployment history by any of them
 - Documentation + Release 1.0.0 + Submit plugin to Strapi Market
 

--- a/admin/src/pages/HomePage.tsx
+++ b/admin/src/pages/HomePage.tsx
@@ -38,11 +38,11 @@ const HomePage = () => {
       const { data } = await get(`/${PLUGIN_ID}/history`);
       setHistory(data.workflow_runs.slice(0, 10));
     } catch (error: any) {
-      console.error(error.name);
       if (error.name === 'AbortError') {
         // User likely just changed page before fetch completed, do nothing
         return;
       } else {
+        console.error(error);
         toggleNotification({
           type: 'danger',
           title: 'Failed to fetch workflow history!',

--- a/admin/src/pages/HomePage.tsx
+++ b/admin/src/pages/HomePage.tsx
@@ -1,9 +1,21 @@
-import { Main, Typography, Button, Flex, Badge, Table, Thead, Tbody, Tr, Th, Td } from '@strapi/design-system';
+import {
+  Main,
+  Typography,
+  Button,
+  Flex,
+  Badge,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+} from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 import { getTranslation } from '../utils/getTranslation';
 import { Play, ArrowClockwise } from '@strapi/icons';
 import { useEffect, useState } from 'react';
-import { useFetchClient, useRBAC } from '@strapi/strapi/admin';
+import { useFetchClient, useNotification, useRBAC } from '@strapi/strapi/admin';
 import { PLUGIN_ID } from '../pluginId';
 import { differenceInMilliseconds, formatRelative } from 'date-fns';
 import pluginPermissions from '../permissions';
@@ -14,7 +26,10 @@ const HomePage = () => {
   const [loadingTriggerButton, setLoadingTriggerButton] = useState(false);
   const [history, setHistory] = useState([]);
   const [loadingHistory, setLoadingHistory] = useState<'loading' | 'planned' | 'none'>('none');
-  const { allowedActions: { canTrigger } } = useRBAC(pluginPermissions.trigger);
+  const {
+    allowedActions: { canTrigger },
+  } = useRBAC(pluginPermissions.trigger);
+  const { toggleNotification } = useNotification();
 
   async function fetchHistory() {
     setLoadingHistory('loading');
@@ -23,8 +38,16 @@ const HomePage = () => {
       const { data } = await get(`/${PLUGIN_ID}/history`);
       setHistory(data.workflow_runs.slice(0, 10));
     } catch (error: any) {
-      console.error(error);
-      window.alert('Failed to fetch workflow history!'); // TODO: Implement toasts
+      console.error(error.name);
+      if (error.name === 'AbortError') {
+        // User likely just changed page before fetch completed, do nothing
+        return;
+      } else {
+        toggleNotification({
+          type: 'danger',
+          title: 'Failed to fetch workflow history!',
+        });
+      }
     } finally {
       setLoadingHistory('none');
     }
@@ -34,7 +57,12 @@ const HomePage = () => {
     try {
       setLoadingTriggerButton(true);
       await post(`/${PLUGIN_ID}/trigger`);
-      window.alert('Successfully started workflow!\n\nHistory will be refetched in 5 seconds'); // TODO: Implement toasts
+      toggleNotification({
+        type: 'success',
+        title: 'Successfully started workflow!',
+        message: 'History will be refetched in 5 seconds',
+        timeout: 5000,
+      });
       setLoadingHistory('planned');
       setTimeout(fetchHistory, 5000);
     } catch (error: any) {
@@ -42,16 +70,26 @@ const HomePage = () => {
       const { status, name } = error.response.data.error;
 
       if (status === 422 && name === 'UnprocessableEntityError') {
-        window.alert('Unprocessable Entity!'); // TODO: Implement toasts
+        toggleNotification({
+          type: 'danger',
+          title: 'Error 422: Unprocessable Entity',
+        });
         return;
       }
 
       if (status === 403 && name === 'PolicyError') {
-        window.alert('Permission Denied!'); // TODO: Implement toasts
+        toggleNotification({
+          type: 'danger',
+          title: 'Error 403: Permission Denied',
+        });
         return;
       }
 
-      window.alert('Unknown Error!'); // TODO: Implement toasts
+      toggleNotification({
+        type: 'danger',
+        title: 'Failed to trigger workflow!',
+        message: 'Unknown error occurred. Please check the console for more details.',
+      });
     } finally {
       setLoadingTriggerButton(false);
     }
@@ -67,15 +105,35 @@ const HomePage = () => {
         padding: '3.2rem 5.4rem',
       }}
     >
-      <Flex direction="row" alignItems="center" justifyContent="space-between" marginBottom='4rem'>
-        <Typography variant='alpha'>{formatMessage({ id: getTranslation('plugin.name') })}</Typography>
+      <Flex direction="row" alignItems="center" justifyContent="space-between" marginBottom="4rem">
+        <Typography variant="alpha">
+          {formatMessage({ id: getTranslation('plugin.name') })}
+        </Typography>
 
-        <Flex direction="row" alignItems="center" gap='1rem'>
-          <Button onClick={fetchHistory} loading={loadingHistory !== 'none'} disabled={loadingTriggerButton} style={{ height: '4.2rem' }} variant='secondary' startIcon={<ArrowClockwise/>}>
-            <Typography fontSize="1.6rem">{formatMessage({ id: getTranslation('reload-button.label') })}</Typography>
+        <Flex direction="row" alignItems="center" gap="1rem">
+          <Button
+            onClick={fetchHistory}
+            loading={loadingHistory !== 'none'}
+            disabled={loadingTriggerButton}
+            style={{ height: '4.2rem' }}
+            variant="secondary"
+            startIcon={<ArrowClockwise />}
+          >
+            <Typography fontSize="1.6rem">
+              {formatMessage({ id: getTranslation('reload-button.label') })}
+            </Typography>
           </Button>
-          <Button onClick={triggerGithubActions} loading={loadingTriggerButton} disabled={loadingHistory !== 'none' || !canTrigger} style={{ height: '4.2rem' }} variant='default' startIcon={<Play/>}>
-            <Typography fontSize="1.6rem">{formatMessage({ id: getTranslation('trigger-button.label') })}</Typography>
+          <Button
+            onClick={triggerGithubActions}
+            loading={loadingTriggerButton}
+            disabled={loadingHistory !== 'none' || !canTrigger}
+            style={{ height: '4.2rem' }}
+            variant="default"
+            startIcon={<Play />}
+          >
+            <Typography fontSize="1.6rem">
+              {formatMessage({ id: getTranslation('trigger-button.label') })}
+            </Typography>
           </Button>
         </Flex>
       </Flex>
@@ -83,11 +141,31 @@ const HomePage = () => {
       <Table colCount={5} rowCount={11}>
         <Thead>
           <Tr>
-            <Th key={'run-number'}><Typography variant='sigma'>{formatMessage({ id: getTranslation('history-table.run-number') })}</Typography></Th>
-            <Th key={'workflow-name'}><Typography variant='sigma'>{formatMessage({ id: getTranslation('history-table.workflow-name') })}</Typography></Th>
-            <Th key={'status'}><Typography variant='sigma'>{formatMessage({ id: getTranslation('history-table.status') })}</Typography></Th>
-            <Th key={'creation-date'}><Typography variant='sigma'>{formatMessage({ id: getTranslation('history-table.creation-date') })}</Typography></Th>
-            <Th key={'duration'}><Typography variant='sigma'>{formatMessage({ id: getTranslation('history-table.duration') })}</Typography></Th>
+            <Th key={'run-number'}>
+              <Typography variant="sigma">
+                {formatMessage({ id: getTranslation('history-table.run-number') })}
+              </Typography>
+            </Th>
+            <Th key={'workflow-name'}>
+              <Typography variant="sigma">
+                {formatMessage({ id: getTranslation('history-table.workflow-name') })}
+              </Typography>
+            </Th>
+            <Th key={'status'}>
+              <Typography variant="sigma">
+                {formatMessage({ id: getTranslation('history-table.status') })}
+              </Typography>
+            </Th>
+            <Th key={'creation-date'}>
+              <Typography variant="sigma">
+                {formatMessage({ id: getTranslation('history-table.creation-date') })}
+              </Typography>
+            </Th>
+            <Th key={'duration'}>
+              <Typography variant="sigma">
+                {formatMessage({ id: getTranslation('history-table.duration') })}
+              </Typography>
+            </Th>
           </Tr>
         </Thead>
         <Tbody>
@@ -95,43 +173,64 @@ const HomePage = () => {
             <Tr>
               <Td></Td>
               <Td></Td>
-              <Td><Typography variant='sigma'>Loading history...</Typography></Td>
-              <Td></Td>
-              <Td></Td>
-            </Tr>
-          )}
-          
-          {loadingHistory === 'planned' && (
-            <Tr>
-              <Td></Td>
-              <Td></Td>
-              <Td><Typography variant='sigma'>Loading history in 5 seconds...</Typography></Td>
+              <Td>
+                <Typography variant="sigma">Loading history...</Typography>
+              </Td>
               <Td></Td>
               <Td></Td>
             </Tr>
           )}
 
-          {loadingHistory === 'none' && (
+          {loadingHistory === 'planned' && (
+            <Tr>
+              <Td></Td>
+              <Td></Td>
+              <Td>
+                <Typography variant="sigma">Loading history in 5 seconds...</Typography>
+              </Td>
+              <Td></Td>
+              <Td></Td>
+            </Tr>
+          )}
+
+          {loadingHistory === 'none' &&
             history.map((workflow: any) => {
-              const msDuration = differenceInMilliseconds(new Date(workflow.updated_at), new Date(workflow.run_started_at));
+              const msDuration = differenceInMilliseconds(
+                new Date(workflow.updated_at),
+                new Date(workflow.run_started_at)
+              );
               const secs = (msDuration / 1000) % 60;
               const mins = Math.floor(msDuration / 1000 / 60);
               const relativeDate = formatRelative(new Date(workflow.created_at), new Date());
               const year = relativeDate.includes('/') ? relativeDate.split('/')[2] : null;
               const month = relativeDate.includes('/') ? relativeDate.split('/')[0] : null;
               const day = relativeDate.includes('/') ? relativeDate.split('/')[1] : null;
-              const ymdRelativeDate = relativeDate.includes('/') ? `${year}-${month}-${day}` : relativeDate;
+              const ymdRelativeDate = relativeDate.includes('/')
+                ? `${year}-${month}-${day}`
+                : relativeDate;
 
               return (
-              <Tr key={workflow.id}>
-                <Td><Typography variant='sigma'>{workflow.run_number}</Typography></Td>
-                <Td><Typography variant='sigma'>{workflow.name}</Typography></Td>
-                <Td><Badge>{workflow.conclusion ?? workflow.status}</Badge></Td>
-                <Td><Typography variant='sigma'>{ymdRelativeDate}</Typography></Td>
-                <Td><Typography variant='sigma'>{workflow.conclusion ? `${mins}m ${secs}s` : 'in progress'}</Typography></Td>
-              </Tr>
-            )})
-          )}
+                <Tr key={workflow.id}>
+                  <Td>
+                    <Typography variant="sigma">{workflow.run_number}</Typography>
+                  </Td>
+                  <Td>
+                    <Typography variant="sigma">{workflow.name}</Typography>
+                  </Td>
+                  <Td>
+                    <Badge>{workflow.conclusion ?? workflow.status}</Badge>
+                  </Td>
+                  <Td>
+                    <Typography variant="sigma">{ymdRelativeDate}</Typography>
+                  </Td>
+                  <Td>
+                    <Typography variant="sigma">
+                      {workflow.conclusion ? `${mins}m ${secs}s` : 'in progress'}
+                    </Typography>
+                  </Td>
+                </Tr>
+              );
+            })}
         </Tbody>
       </Table>
     </Main>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-static-deploy",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Trigger Github workflows to build and deploy statically generated websites",
   "license": "MIT",
   "strapi": {


### PR DESCRIPTION
- Use `useNotification` hook from Strapi instead of `window.alert` for a more cohesive experience
- Prevent notifying user of any history fetching error that's an `AbortError`, which usually just signifies the user exited the plugin's page before fetching could be completed