### PR TITLE
Allow adding a mandatory staging workflow before the regular one

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Appropriate documentation will come with version 1.0.0.
 - Automatic refresh of the history of deployments after trigger ✅
 - Link to workflow run's github page ✅
 - Allow multiple workflows
+- Add the option to include a mandatory staging workflow before any workflow ✅
 
 ## Credits
 This plugin was born as a Strapi V5-compatible version of [Update Static Content](https://github.com/everythinginjs/strapi-plugin-update-static-content) by [Amir Mahmoudi](https://github.com/everythinginjs)

--- a/admin/src/pages/HomePage.tsx
+++ b/admin/src/pages/HomePage.tsx
@@ -13,7 +13,7 @@ import {
 } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 import { getTranslation } from '../utils/getTranslation';
-import { Play, ArrowClockwise, ExternalLink, Eye } from '@strapi/icons';
+import { Play, ArrowClockwise, ExternalLink, Expand } from '@strapi/icons';
 import { useEffect, useState } from 'react';
 import { ConfirmDialog, useFetchClient, useNotification, useRBAC } from '@strapi/strapi/admin';
 import { PLUGIN_ID } from '../pluginId';
@@ -28,7 +28,7 @@ import { IconButton } from '@strapi/design-system';
 const HomePage = () => {
   const { formatMessage } = useIntl();
   const { get, post } = useFetchClient();
-  const [loadingTriggerButton, setLoadingTriggerButton] = useState(false);
+  const [loadingTriggerButton, setLoadingTriggerButton] = useState(false); // TODO: Maybe separate loadingTriggerButton from loadingStagingButton
   const [config, setConfig] = useState<Config | null>(null);
   const [history, setHistory] = useState<Array<Workflow>>([]);
   const [loadingHistory, setLoadingHistory] = useState<'loading' | 'planned' | 'none'>('none');
@@ -147,17 +147,44 @@ const HomePage = () => {
             onOpenChange={setShowTriggerConfirmationPopup}
           >
             <Dialog.Trigger>
-              <Button
-                loading={loadingTriggerButton}
-                disabled={loadingHistory !== 'none' || !canTrigger}
-                style={{ height: '4.2rem' }}
-                variant="default"
-                startIcon={<Play />}
-              >
-                <Typography fontSize="1.6rem">
-                  {formatMessage({ id: getTranslation('trigger-button.label') })}
-                </Typography>
-              </Button>
+              {config?.staging ? (
+                <Flex>
+                  <Button
+                    loading={loadingTriggerButton}
+                    disabled={loadingHistory !== 'none' || !canTrigger}
+                    style={{ height: '4.2rem', borderTopRightRadius: 0, borderBottomRightRadius: 0 }}
+                    variant="default"
+                    startIcon={<Expand />}
+                  >
+                    <Typography fontSize="1.6rem">
+                      {formatMessage({ id: getTranslation('staging-button.label') })}
+                    </Typography>
+                  </Button>
+                  <Button
+                    loading={loadingTriggerButton}
+                    disabled={loadingHistory !== 'none' || !canTrigger}
+                    style={{ height: '4.2rem', borderTopLeftRadius: 0, borderBottomLeftRadius: 0 }}
+                    variant="default"
+                    startIcon={<Play />}
+                  >
+                    <Typography fontSize="1.6rem">
+                      {formatMessage({ id: getTranslation('trigger-button.label') })}
+                    </Typography>
+                  </Button>
+                </Flex>
+              ) : (
+                <Button
+                  loading={loadingTriggerButton}
+                  disabled={loadingHistory !== 'none' || !canTrigger}
+                  style={{ height: '4.2rem' }}
+                  variant="default"
+                  startIcon={<Play />}
+                >
+                  <Typography fontSize="1.6rem">
+                    {formatMessage({ id: getTranslation('trigger-button.label') })}
+                  </Typography>
+                </Button>
+              )}
             </Dialog.Trigger>
 
             <ConfirmDialog
@@ -178,6 +205,9 @@ const HomePage = () => {
       </Flex>
 
       <Table colCount={5} rowCount={11}>
+        {
+          // TODO: Add staging workflow runs to table
+        }
         <Thead>
           <Tr>
             <Th key={'run-number'}>

--- a/admin/src/translations/en.json
+++ b/admin/src/translations/en.json
@@ -1,6 +1,7 @@
 {
   "static-deploy.plugin.name": "Deploy Static Site",
   "static-deploy.trigger-button.label": "Trigger",
+  "static-deploy.staging-button.label": "Staging",
   "static-deploy.reload-button.label": "Reload History",
   "static-deploy.history-table.run-number": "RUN NUMBER",
   "static-deploy.history-table.workflow-name": "WORKFLOW NAME",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-static-deploy",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Trigger Github workflows to build and deploy statically generated websites",
   "license": "MIT",
   "strapi": {

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -4,11 +4,16 @@ type Validator = Partial<Config>;
 
 export default {
   default: {},
-  validator({ owner, repo, branch, workflowID, githubToken, environment }: Validator) {
+  validator({ owner, repo, branch, workflowID, githubToken, environment, staging }: Validator) {
+    // Check if required keys are present
     if (!(owner && repo && branch && workflowID && githubToken)) {
-      return;
+      throw new Error('`owner`, `repo`, `branch`, `workflowID` and `githubToken` keys in your plugin config are required');
+    }
+    if (staging && !staging.workflowID) {
+      throw new Error('`staging.workflowID` key in your plugin config is missing, either set it to a string or remove the whole staging object');
     }
 
+    // Check if base config is valid
     if (owner && typeof owner !== 'string') {
       throw new Error('`owner` key in your plugin config has to be a string');
     }
@@ -26,6 +31,17 @@ export default {
     }
     if (environment && typeof environment !== 'string') {
       throw new Error('`environment` key in your plugin config has to be a string');
+    }
+
+    // Check if staging config is valid
+    if (staging && typeof staging.workflowID !== 'string') {
+      throw new Error('`staging.workflowID` key in your plugin config has to be a string');
+    }
+    if (staging && staging.branch && typeof staging.branch !== 'string') {
+      throw new Error('`staging.githubToken` key in your plugin config has to be a string');
+    }
+    if (staging && staging.environment && typeof staging.environment !== 'string') {
+      throw new Error('`staging.environment` key in your plugin config has to be a string');
     }
   },
 };

--- a/server/src/content-types/index.ts
+++ b/server/src/content-types/index.ts
@@ -1,1 +1,34 @@
-export default {};
+export default {
+    'staging-status': {
+        schema: {
+            kind: 'singleType',
+            collectionName: 'staging_status',
+            info: {
+                name: 'StagingStatus',
+                singularName: 'staging-status',
+                pluralName: 'staging-statuses',
+                displayName: 'Staging Status',
+                tableName: 'staging_status',
+                description: 'Shows if user is allowed to deploy to production, that is, if no updates have been published since last deploy to staging',
+            },
+            options: {
+                draftAndPublish: false,
+            },
+            pluginOptions: {
+              'content-manager': {
+                visible: false,
+              },
+              'content-type-builder': {
+                visible: false,
+              },
+            },
+            attributes: {
+              unstagedUpdates: {
+                type: 'boolean',
+                required: true,
+                default: true,
+              },
+            },
+        }
+    }
+};

--- a/server/src/controllers/index.ts
+++ b/server/src/controllers/index.ts
@@ -1,4 +1,5 @@
 import githubActions from './githubActions';
 import config from './config';
+import stagingStatus from './stagingStatus';
 
-export default { githubActions, config };
+export default { githubActions, config, stagingStatus };

--- a/server/src/controllers/stagingStatus.ts
+++ b/server/src/controllers/stagingStatus.ts
@@ -1,0 +1,21 @@
+import { PLUGIN_ID } from '../../../admin/src/pluginId';
+
+const stagingStatusController = {
+  async get(ctx: any) {
+    const serviceResult = await strapi.plugin(PLUGIN_ID).service('stagingStatus').get();
+    ctx.send(serviceResult);
+  },
+  async set(ctx: any) {
+    const newDocumentData = ctx.request.body;
+
+    if (typeof newDocumentData === 'object' && typeof newDocumentData.unstagedUpdates === 'boolean') {
+      const serviceResult = await strapi.plugin(PLUGIN_ID).service('stagingStatus').set(newDocumentData);
+      ctx.send(serviceResult);
+      return;
+    }
+
+    ctx.send({ success: false, error: 'Invalid data' });                               
+  }
+};
+
+export default stagingStatusController;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -24,7 +24,7 @@ export default {
   controllers,
   routes,
   services,
-  // contentTypes,
+  contentTypes,
   // policies,
   // middlewares,
 };

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -25,5 +25,21 @@ export default {
         policies: ['admin::isAuthenticatedAdmin'],
       },
     },
+    {
+      method: 'GET',
+      path: '/staging-status',
+      handler: 'stagingStatus.get',
+      config: {
+        policies: ['admin::isAuthenticatedAdmin'],
+      },
+    },
+    {
+      method: 'POST',
+      path: '/staging-status',
+      handler: 'stagingStatus.set',
+      config: {
+        policies: ['admin::isAuthenticatedAdmin'],
+      },
+    },
   ],
 };

--- a/server/src/services/config.ts
+++ b/server/src/services/config.ts
@@ -11,6 +11,7 @@ const configService = ({ strapi }: { strapi: Core.Strapi }) => ({
       const githubToken = strapi.plugin(PLUGIN_ID).config('githubToken');
       const environment = strapi.plugin(PLUGIN_ID).config('environment'); // TODO: Generalize this to inputs to be able to add any input
       const hideGithubLink = strapi.plugin(PLUGIN_ID).config('hideGithubLink');
+      const staging = strapi.plugin(PLUGIN_ID).config('staging');
 
       return {
         owner,
@@ -20,6 +21,7 @@ const configService = ({ strapi }: { strapi: Core.Strapi }) => ({
         githubToken,
         environment,
         hideGithubLink,
+        staging,
       };
     } catch (err: any) {
       return err.response;

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -1,4 +1,5 @@
 import config from './config';
 import githubActions from './githubActions';
+import stagingStatus from './stagingStatus';
 
-export default { githubActions, config };
+export default { githubActions, config, stagingStatus };

--- a/server/src/services/stagingStatus.ts
+++ b/server/src/services/stagingStatus.ts
@@ -1,0 +1,65 @@
+import { Core } from '@strapi/strapi';
+import { PLUGIN_ID } from '../../../admin/src/pluginId';
+import StagingStatus from '../../../types/StagingStatus';
+
+const stagingStatusService = ({ strapi }: { strapi: Core.Strapi }) => ({
+  async get() {
+    try {
+      const unstagedUpdates = await strapi
+        .documents(`plugin::${PLUGIN_ID}.staging-status`)
+        .findMany({
+          sort: 'createdAt:desc', // Most recent first
+        });
+
+      const currDocument =
+        unstagedUpdates.length < 1 // No documents yet, create one
+          ? await strapi.documents(`plugin::${PLUGIN_ID}.staging-status`).create({
+              data: {
+                unstagedUpdates: true,
+              },
+            })
+          : unstagedUpdates[0];
+
+      if (unstagedUpdates.length > 1) {
+        // More than one document, delete all but the latest one
+        unstagedUpdates.forEach(async (doc, idx) => {
+          if (idx !== 0) {
+            await strapi
+              .documents(`plugin::${PLUGIN_ID}.staging-status`)
+              .delete({ documentId: doc.documentId });
+          }
+        });
+      }
+
+      return { unstagedUpdates: currDocument.unstagedUpdates };
+    } catch (err: any) {
+      return err.response;
+    }
+  },
+  async set(newDocumentData: StagingStatus) {
+    try {
+      const unstagedUpdates = await strapi
+        .documents(`plugin::${PLUGIN_ID}.staging-status`)
+        .findMany({
+          sort: 'updatedAt:desc', // Most recent first
+        });
+
+        // Delete all documents before creating a new one (cleaner than updating)
+        unstagedUpdates.forEach(async (doc, idx) => {
+          if (idx !== 0) {
+            await strapi
+              .documents(`plugin::${PLUGIN_ID}.staging-status`)
+              .delete({ documentId: doc.documentId });
+          }
+        });
+
+        // Create new document
+        await strapi.documents(`plugin::${PLUGIN_ID}.staging-status`).create({ data: newDocumentData });
+        return { success: true, error: null };
+    } catch (err: any) {
+      return { success: false, error: err.response };
+    }
+  }
+});
+
+export default stagingStatusService;

--- a/types/Config.ts
+++ b/types/Config.ts
@@ -6,4 +6,9 @@ export default interface Config {
   githubToken: string;
   environment: string;
   hideGithubLink?: boolean;
+  staging?: {
+    workflowID: string;
+    branch?: string;
+    environment?: string;
+  }
 }

--- a/types/StagingStatus.ts
+++ b/types/StagingStatus.ts
@@ -1,0 +1,3 @@
+export default interface StagingStatus {
+  unstagedUpdates: boolean;
+}


### PR DESCRIPTION
# WIP

If any user published changes since the last deploy to staging, the standard Trigger button will be disabled until a new deploy to staging is ran.

Up next:
- Track unstaged updates whenever a user publishes anything --> The content-types to be monitored may need to be expressly listed in the configuration of the plugin if Strapi offers no way of intercepting publishing in general
- Refine Homepage UX/functionality (make sure each button triggers correct workflow, etc...)

Optional enhancements:
- Disable Trigger button (and enable staging one) if last staging deploy has not completed successfully (or hasn't yet)