### PR TITLE
Add email notifications on workflow trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Appropriate documentation will come with version 1.0.0.
 - Filter deployment history by `environment` ✅
 - **Optional:** Implement toasts for user feedback (although alerts are kinda nice because they force you to read and click to dismiss them) ✅
 - Generalize the `environment` parameter to an `inputs` array and allow users to configure whether they want to filter deployment history by any of them
+- Add email notifications on workflow trigger ✅
+- Add email notifications on workflow completion
 - Documentation + Release 1.0.0 + Submit plugin to Strapi Market
 
 ### Possible further enhancements
@@ -24,6 +26,7 @@ Appropriate documentation will come with version 1.0.0.
 - Allow multiple workflows
 - Add the option to include a mandatory staging workflow before any workflow ✅
 - Allow configuration of specific content types list to monitor for updates when determining staging status (currently disables production deployment after ANY publish action)
+- Split each email notification trigger (staging trigger, prod trigger, staging workflow end, prod workflow end) to allow for finer configuration
 
 ## Credits
 This plugin was born as a Strapi V5-compatible version of [Update Static Content](https://github.com/everythinginjs/strapi-plugin-update-static-content) by [Amir Mahmoudi](https://github.com/everythinginjs)

--- a/admin/src/pages/App.tsx
+++ b/admin/src/pages/App.tsx
@@ -1,14 +1,67 @@
-import { Page } from '@strapi/strapi/admin';
-import { Routes, Route } from 'react-router-dom';
+import { Page, useRBAC } from '@strapi/strapi/admin';
+import { Routes, Route, useLocation } from 'react-router-dom';
 
 import { HomePage } from './HomePage';
 import pluginPermissions from '../permissions';
+import { NotificationsPage } from './NotificationsPage';
+import { Flex } from '@strapi/design-system';
+import { BaseLink } from '@strapi/design-system';
+import { Typography } from '@strapi/design-system';
+import { useIntl } from 'react-intl';
+import { getTranslation } from '../utils/getTranslation';
+import { Link } from '@strapi/design-system';
 
 const App = () => {
+  const { formatMessage } = useIntl();
+  const location = useLocation();
+  const {
+    allowedActions: { canNotifications },
+  } = useRBAC(pluginPermissions.notifications);
+
   return (
     <Page.Protect permissions={pluginPermissions.access}>
+      <Flex
+        direction="row"
+        alignItems="center"
+        justifyContent="space-between"
+        style={{
+          borderBottom: '1px solid rgba(255, 255, 255, .2)',
+          padding: '2rem 5.4rem',
+          marginBottom: '3.2rem',
+        }}
+      >
+        <Typography variant="beta">
+          {formatMessage({ id: getTranslation('plugin.name') })}
+        </Typography>
+
+        <Flex direction="row" alignItems="center" gap="2rem">
+          <Link
+            href="/admin/static-deploy"
+            style={{
+              textDecoration: location.pathname === '/static-deploy' ? 'underline' : 'none',
+            }}
+          >
+            <Typography variant="gamma" color="white !important">
+              Deployments
+            </Typography>
+          </Link>
+          <Link
+            href="/admin/static-deploy/notifications"
+            disabled={!canNotifications}
+            style={{
+              textDecoration:
+                location.pathname === '/static-deploy/notifications' ? 'underline' : 'none',
+            }}
+          >
+            <Typography variant="gamma" {...(canNotifications && { color: 'white !important' })}>
+              Notifications
+            </Typography>
+          </Link>
+        </Flex>
+      </Flex>
       <Routes>
         <Route index element={<HomePage />} />
+        <Route path="notifications" element={<NotificationsPage />} />
         <Route path="*" element={<Page.Error />} />
       </Routes>
     </Page.Protect>

--- a/admin/src/pages/HomePage.tsx
+++ b/admin/src/pages/HomePage.tsx
@@ -50,6 +50,14 @@ const HomePage = () => {
     }
   }
 
+  async function sendEmailNotification(event: 'staging-trigger' | 'prod-trigger' | 'trigger') {
+    try {
+      post(`/${PLUGIN_ID}/notify`, { event });
+    } catch (error: any) {
+      console.error(error);
+    }
+  }
+
   async function getStagingStatus(): Promise<StagingStatus | null> {
     try {
       const { data } = await get<StagingStatus>(`/${PLUGIN_ID}/staging-status`);
@@ -211,6 +219,7 @@ const HomePage = () => {
       if (config?.staging && unstagedUpdates) {
         // Staging
         await post(`/${PLUGIN_ID}/trigger-staging`);
+        sendEmailNotification('staging-trigger');
       } else {
         // Prod
         // Check for unstaged updates to prevent triggering if another editor published changes while the user was on this page
@@ -239,7 +248,9 @@ const HomePage = () => {
         }
 
         await post(`/${PLUGIN_ID}/trigger`);
+        sendEmailNotification(config?.staging ? 'prod-trigger' : 'trigger');
       }
+
 
       toggleNotification({
         type: 'success',
@@ -314,13 +325,11 @@ const HomePage = () => {
   return (
     <Main
       style={{
-        padding: '3.2rem 5.4rem',
+        padding: '0 5.4rem 3.2rem 5.4rem',
       }}
     >
       <Flex direction="row" alignItems="center" justifyContent="space-between" marginBottom="4rem">
-        <Typography variant="alpha">
-          {formatMessage({ id: getTranslation('plugin.name') })}
-        </Typography>
+        <Typography variant="alpha">Deployments</Typography>
 
         <Flex direction="row" alignItems="center" gap="1rem">
           <Button

--- a/admin/src/pages/NotificationsPage.tsx
+++ b/admin/src/pages/NotificationsPage.tsx
@@ -1,0 +1,239 @@
+import { Main } from '@strapi/design-system';
+import { Page, ConfirmDialog, useFetchClient, useNotification } from '@strapi/strapi/admin';
+import pluginPermissions from '../permissions';
+import { Flex } from '@strapi/design-system';
+import { Typography } from '@strapi/design-system';
+import { Dialog } from '@strapi/design-system';
+import { useEffect, useState } from 'react';
+import { Button } from '@strapi/design-system';
+import { Plus, Trash } from '@strapi/icons';
+import { getTranslation } from '../utils/getTranslation';
+import { useIntl } from 'react-intl';
+import { TextInput } from '@strapi/design-system';
+import { Table } from '@strapi/design-system';
+import { Thead } from '@strapi/design-system';
+import { Tr } from '@strapi/design-system';
+import { Th } from '@strapi/design-system';
+import { Tbody } from '@strapi/design-system';
+import { PLUGIN_ID } from '../pluginId';
+import { Td } from '@strapi/design-system';
+import { Tooltip } from '@strapi/design-system';
+import { IconButton } from '@strapi/design-system';
+import { VisuallyHidden } from '@strapi/design-system';
+
+const NotificationsPage = () => {
+  const { formatMessage } = useIntl();
+  const { get, post, del } = useFetchClient();
+  const [showAddEmailPopup, setShowAddEmailPopup] = useState(false);
+  const [showConfirmEmailDeletionPopup, setShowConfirmEmailDeletionPopup] = useState(false);
+  const [emailsForNotifications, setEmailsForNotifications] = useState([]);
+  const [newEmail, setNewEmail] = useState<string | undefined>();
+  const [emailToDelete, setEmailToDelete] = useState<string | undefined>();
+  const { toggleNotification } = useNotification();
+
+  function validateNewEmail(email: string) {
+    if (email === '') {
+        setNewEmail(undefined);
+        return;
+    }
+
+    if (email.match(/^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/)) {
+        setNewEmail(email);
+        return;
+    }
+
+    setNewEmail(undefined);
+  }
+
+  async function getEmailsForNotifications() {
+    try {
+      const { data } = await get(`/${PLUGIN_ID}/emails-for-notifications`);
+      if (data.success) {
+        setEmailsForNotifications(data.emails);
+      } else {
+        console.error(data.err);
+        setEmailsForNotifications([]);
+      }
+    } catch (error: any) {
+      console.error(error);
+      setEmailsForNotifications([]);
+    }
+  }
+
+  async function addNewEmail() {
+    try {
+        const { data } = await post(`/${PLUGIN_ID}/emails-for-notifications`, { newEmail });
+        if (data.success) {
+            setNewEmail(undefined);
+            getEmailsForNotifications();
+            toggleNotification({
+                type: 'success',
+                title: 'Email added successfully!',
+                timeout: 5000,
+            });
+        } else {
+            console.error(data.err);
+            toggleNotification({
+                type: 'danger',
+                title: 'Failed to add email',
+                message: 'Please try again',
+                timeout: 5000,
+            });
+        }
+    } catch (error: any) {
+        console.error(error);
+        toggleNotification({
+            type: 'danger',
+            title: 'Failed to add email',
+            message: 'Please try again',
+            timeout: 5000,
+        });
+    }
+  }
+
+  async function deleteEmail() {
+    try {
+        const { data } = await del(`/${PLUGIN_ID}/emails-for-notifications`, { params: { email: emailToDelete } });
+        if (data.success) {
+            getEmailsForNotifications();
+            toggleNotification({
+                type: 'success',
+                title: 'Email removed successfully!',
+                timeout: 5000,
+            });
+        } else {
+            console.error(data.err);
+            toggleNotification({
+                type: 'danger',
+                title: 'Failed to add email',
+                message: 'Please try again',
+                timeout: 5000,
+            });
+        }
+    } catch (error: any) {
+        console.error(error);
+        toggleNotification({
+            type: 'danger',
+            title: 'Failed to remove email',
+            message: 'Please try again',
+            timeout: 5000,
+        });
+    } finally {
+        setEmailToDelete(undefined);
+    }
+  }
+
+  useEffect(() => {
+    getEmailsForNotifications();
+  }, []);
+
+  useEffect(() => {
+    if (emailToDelete && !showConfirmEmailDeletionPopup) {
+        setShowConfirmEmailDeletionPopup(true);
+    }
+  }, [emailToDelete]);
+
+  return (
+    <Page.Protect permissions={pluginPermissions.notifications}>
+      <Main
+        style={{
+          padding: '0 5.4rem 3.2rem 5.4rem',
+        }}
+      >
+        <Flex
+          direction="row"
+          alignItems="center"
+          justifyContent="space-between"
+          marginBottom="4rem"
+        >
+          <Typography variant="alpha">Email Notifications</Typography>
+
+          <Flex direction="row" alignItems="center" gap="1rem">
+            <Dialog.Root open={showAddEmailPopup} onOpenChange={setShowAddEmailPopup}>
+              <Dialog.Trigger>
+                <Button style={{ height: '4.2rem' }} variant="default" startIcon={<Plus />}>
+                  <Typography fontSize="1.6rem">
+                    {formatMessage({ id: getTranslation('add-email-button.label') })}
+                  </Typography>
+                </Button>
+              </Dialog.Trigger>
+
+              <Dialog.Content>
+                <Dialog.Header>Add Email Address</Dialog.Header>
+                <Dialog.Body>
+                  <Flex direction="column" alignItems="stretch" gap="1rem" width="100%">
+                    <Typography>This address will receive email notifications</Typography>
+                    <TextInput type="email" placeholder="Email Address" onChange={(e: any) => validateNewEmail(e.target.value)}/>
+                  </Flex>
+                </Dialog.Body>
+                <Dialog.Footer>
+                  <Dialog.Cancel>
+                    <Button fullWidth variant="tertiary">
+                      Cancel
+                    </Button>
+                  </Dialog.Cancel>
+                  <Dialog.Action>
+                    <Button fullWidth variant="success-light" disabled={!newEmail} onClick={addNewEmail}>
+                      Confirm
+                    </Button>
+                  </Dialog.Action>
+                </Dialog.Footer>
+              </Dialog.Content>
+            </Dialog.Root>
+          </Flex>
+        </Flex>
+
+        <Table colCount={2}>
+          <Thead>
+            <Tr>
+              <Th key={'email'}>
+                <Typography variant="sigma">Email Address</Typography>
+              </Th>
+              <Th key={'actions'}></Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {emailsForNotifications.length <= 0 && (
+              <Tr key="empty">
+                <Td>
+                  <Typography variant="sigma">No Emails</Typography>
+                </Td>
+                <Td />
+              </Tr>
+            )}
+
+            {emailsForNotifications.map((email: string) => (
+              <Tr key={email}>
+                <Td>
+                  <Typography variant="sigma">{email}</Typography>
+                </Td>
+                <Td>
+                    <Tooltip description="Remove Email">
+                        <IconButton aria-label="Remove Email" marginLeft='auto' onClick={() => setEmailToDelete(email)}>
+                            <Trash />
+                        </IconButton>
+                    </Tooltip>
+                </Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+
+        <Dialog.Root open={showConfirmEmailDeletionPopup} onOpenChange={setShowConfirmEmailDeletionPopup}>
+            <ConfirmDialog
+                variant="default"
+                icon={null}
+                onConfirm={deleteEmail}
+                // @ts-ignore
+                onCancel={() => setEmailToDelete(undefined)}
+                title="Confirm Email Deletion?"
+            >
+                <Typography fontSize="1.4rem">The address [{emailToDelete}] will stop receiving all email notifications</Typography>
+            </ConfirmDialog>
+        </Dialog.Root>
+      </Main>
+    </Page.Protect>
+  );
+};
+
+export { NotificationsPage };

--- a/admin/src/permissions.ts
+++ b/admin/src/permissions.ts
@@ -13,6 +13,12 @@ const pluginPermissions = {
       subject: null,
     },
   ],
+  notifications: [
+    {
+      action: `plugin::${PLUGIN_ID}.notifications`,
+      subject: null,
+    },
+  ],
 };
 
 export default pluginPermissions;

--- a/admin/src/translations/en.json
+++ b/admin/src/translations/en.json
@@ -7,5 +7,6 @@
   "static-deploy.history-table.workflow-name": "WORKFLOW NAME",
   "static-deploy.history-table.status": "STATUS",
   "static-deploy.history-table.creation-date": "CREATION DATE",
-  "static-deploy.history-table.duration": "DURATION"
+  "static-deploy.history-table.duration": "DURATION",
+  "static-deploy.add-email-button.label": "Add Email"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-static-deploy",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Trigger Github workflows to build and deploy statically generated websites",
   "license": "MIT",
   "strapi": {

--- a/server/src/bootstrap.ts
+++ b/server/src/bootstrap.ts
@@ -13,6 +13,13 @@ const bootstrap = async ({ strapi }: { strapi: Core.Strapi }) => {
     },
     {
       section: 'plugins',
+      subCategory: 'general',
+      displayName: 'Manage Email Notifications',
+      uid: 'notifications',
+      pluginName: PLUGIN_ID,
+    },
+    {
+      section: 'plugins',
       subCategory: 'actions',
       displayName: 'Trigger builds',
       uid: 'trigger',

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -4,7 +4,7 @@ type Validator = Partial<Config>;
 
 export default {
   default: {},
-  validator({ owner, repo, branch, workflowID, githubToken, environment, staging }: Validator) {
+  validator({ owner, repo, branch, workflowID, githubToken, environment, staging, enableEmailNotifications }: Validator) {
     // Check if required keys are present
     if (!(owner && repo && branch && workflowID && githubToken)) {
       throw new Error('`owner`, `repo`, `branch`, `workflowID` and `githubToken` keys in your plugin config are required');

--- a/server/src/content-types/index.ts
+++ b/server/src/content-types/index.ts
@@ -30,5 +30,37 @@ export default {
               },
             },
         }
+    },
+    'email-for-notifications': {
+        schema: {
+            kind: 'collectionType',
+            collectionName: 'email_for_notifications',
+            info: {
+              name: 'EmailForNotifications',
+              singularName: 'email-for-notifications',
+              pluralName: 'emails-for-notifications',
+              displayName: 'Email For Notifications',
+              tableName: 'email_for_notifications',
+              description: 'Stores a list of email addresses that should receive notifications upon predetermined events such as workflow launch or workflow completion',
+            },
+            options: {
+              draftAndPublish: false,
+            },
+            pluginOptions: {
+              'content-manager': {
+                visible: false,
+              },
+              'content-type-builder': {
+                visible: false,
+              },
+            },
+            attributes: {
+              email: {
+                type: 'email',
+                required: true,
+                unique: true,
+              },
+            },
+        }
     }
 };

--- a/server/src/controllers/index.ts
+++ b/server/src/controllers/index.ts
@@ -1,5 +1,6 @@
 import githubActions from './githubActions';
 import config from './config';
 import stagingStatus from './stagingStatus';
+import notifications from './notifications';
 
-export default { githubActions, config, stagingStatus };
+export default { githubActions, config, stagingStatus, notifications };

--- a/server/src/controllers/notifications.ts
+++ b/server/src/controllers/notifications.ts
@@ -1,0 +1,29 @@
+import { PLUGIN_ID } from '../../../admin/src/pluginId';
+
+const notificationsController = {
+  async send(ctx: any) {
+    const { event } = ctx.request.body;
+    const serviceResult = await strapi.plugin(PLUGIN_ID).service('notifications').send(event);
+    ctx.send(serviceResult);
+  },
+  async getEmails(ctx: any) {
+    const serviceResult = await strapi.plugin(PLUGIN_ID).service('notifications').getEmails();
+    ctx.send(serviceResult);
+  },
+  async addEmail(ctx: any) {
+    const { newEmail } = ctx.request.body;
+    const serviceResult = await strapi.plugin(PLUGIN_ID).service('notifications').addEmail(newEmail);
+    ctx.send(serviceResult);
+  },
+  async deleteEmail(ctx: any) {
+    const reqURL = new URL(ctx.request.url, 'http://localhost:1337');
+    if (reqURL.searchParams.has('email')) {
+      const serviceResult = await strapi.plugin(PLUGIN_ID).service('notifications').deleteEmail(reqURL.searchParams.get('email'));
+      ctx.send(serviceResult);
+    } else {
+      ctx.send({ success: false, err: 'Missing email parameter' });
+    }
+  },
+};
+
+export default notificationsController;

--- a/server/src/register.ts
+++ b/server/src/register.ts
@@ -25,6 +25,7 @@ const register = ({ strapi }: { strapi: Core.Strapi }) => {
 
     if (
       context.contentType.uid !== `plugin::${PLUGIN_ID}.staging-status` && // Prevent infinite loop
+      context.contentType.uid !== `plugin::${PLUGIN_ID}.email-for-notifications` && // Managing this plugin's notifications should not affect the staging status
       triggerActions.includes(context.action) &&
       !deletingDraftOnlyDocument
     ) {

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -49,5 +49,37 @@ export default {
         policies: ['admin::isAuthenticatedAdmin'],
       },
     },
+    {
+      method: 'GET',
+      path: '/emails-for-notifications',
+      handler: 'notifications.getEmails',
+      config: {
+        policies: ['admin::isAuthenticatedAdmin'],
+      },
+    },
+    {
+      method: 'POST',
+      path: '/emails-for-notifications',
+      handler: 'notifications.addEmail',
+      config: {
+        policies: ['admin::isAuthenticatedAdmin'],
+      },
+    },
+    {
+      method: 'DELETE',
+      path: '/emails-for-notifications',
+      handler: 'notifications.deleteEmail',
+      config: {
+        policies: ['admin::isAuthenticatedAdmin'],
+      },
+    },
+    {
+      method: 'POST',
+      path: '/notify',
+      handler: 'notifications.send',
+      config: {
+        policies: ['admin::isAuthenticatedAdmin'],
+      },
+    },
   ],
 };

--- a/server/src/services/config.ts
+++ b/server/src/services/config.ts
@@ -11,6 +11,7 @@ const configService = ({ strapi }: { strapi: Core.Strapi }) => ({
       const githubToken = strapi.plugin(PLUGIN_ID).config('githubToken');
       const environment = strapi.plugin(PLUGIN_ID).config('environment'); // TODO: Generalize this to inputs to be able to add any input
       const hideGithubLink = strapi.plugin(PLUGIN_ID).config('hideGithubLink');
+      const enableEmailNotifications = strapi.plugin(PLUGIN_ID).config('enableEmailNotifications');
       const staging = strapi.plugin(PLUGIN_ID).config('staging');
 
       return {
@@ -21,6 +22,7 @@ const configService = ({ strapi }: { strapi: Core.Strapi }) => ({
         githubToken,
         environment,
         hideGithubLink,
+        enableEmailNotifications,
         staging,
       };
     } catch (err: any) {

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -1,5 +1,6 @@
 import config from './config';
 import githubActions from './githubActions';
 import stagingStatus from './stagingStatus';
+import notifications from './notifications';
 
-export default { githubActions, config, stagingStatus };
+export default { githubActions, config, stagingStatus, notifications };

--- a/server/src/services/notifications.ts
+++ b/server/src/services/notifications.ts
@@ -1,0 +1,79 @@
+import { type Core,  } from '@strapi/strapi';
+import { PLUGIN_ID } from '../../../admin/src/pluginId';
+import Config from '../../../types/Config';
+
+const notificationTitle: Record<'staging-trigger' | 'prod-trigger' | 'trigger', string> = {
+  'staging-trigger': 'Staging Workflow Triggered',
+  'prod-trigger': 'Production Workflow Triggered',
+  'trigger': 'Workflow Triggered'
+}
+
+const notificationBody = (workflowID: string, url: string): Record<'staging-trigger' | 'prod-trigger' | 'trigger', string> => ({
+  'staging-trigger': `A run of the staging workflow (ID: ${workflowID}) has been triggered!<br/>You can access the ${url === '' ? 'admin panel' : `<a href='${url}'>admin panel</a>`} to check and manage workflows.<br/><br/><small>This email was generated automatically</small>`,
+  'prod-trigger': `A run of the production workflow (ID: ${workflowID}) has been triggered!<br/>You can access the ${url === '' ? 'admin panel' : `<a href='${url}'>admin panel</a>`} to check and manage workflows.<br/><br/><small>This email was generated automatically</small>`,
+  'trigger': `A workflow run (ID: ${workflowID}) has been triggered!<br/>You can access the ${url === '' ? 'admin panel' : `<a href='${url}'>admin panel</a>`} to check and manage workflows.<br/><br/><small>This email was generated automatically</small>`
+})
+
+const notificationsService = ({ strapi }: { strapi: Core.Strapi }) => ({
+  async send(event: 'staging-trigger' | 'prod-trigger' | 'trigger') {
+    try {
+        const workflowID: Config['workflowID'] = strapi.plugin(PLUGIN_ID).config('workflowID');
+        const staging: Config['staging'] = strapi.plugin(PLUGIN_ID).config('staging');
+        const notifications: Config['enableEmailNotifications'] = strapi.plugin(PLUGIN_ID).config('enableEmailNotifications');
+        const url: string = strapi.config.get('server.url');
+
+        if (!notifications) {
+          return { enabled: false, success: true };
+        }
+
+        const emails = (await strapi.documents(`plugin::${PLUGIN_ID}.email-for-notifications`).findMany({ sort: 'email:asc' })).map(doc => doc.email);
+
+        if (emails.length > 0) {
+          strapi.plugin('email').services.email.send({
+              to: emails.join(','),
+              subject: notificationTitle[event],
+              html: notificationBody(event === 'staging-trigger' ? (staging?.workflowID ?? '') : workflowID, url)[event],
+          });
+        }
+        
+        return { enabled: true, success: true };
+    } catch (err: any) {
+      return err.response;
+    }
+  },
+  async getEmails() {
+    try {
+      const emails = (await strapi.documents(`plugin::${PLUGIN_ID}.email-for-notifications`).findMany({ sort: 'email:asc' })).map(doc => doc.email);
+      return { success: true, emails };
+    } catch (err: any) {
+      return { success: false, err };
+    }
+  },
+  async addEmail(newEmail: string) {
+    try {
+      await strapi.documents(`plugin::${PLUGIN_ID}.email-for-notifications`).create({ data: { email: newEmail.toLowerCase() } })
+      return { success: true };
+    } catch (err: any) {
+      return { success: false, err };
+    }
+  },
+  async deleteEmail(emailToDelete: string) {
+    try {
+      const docToDelete = await strapi.documents(`plugin::${PLUGIN_ID}.email-for-notifications`).findFirst({ filters: {
+        email: {
+          $eqi: emailToDelete
+        }
+      }});
+
+      if (docToDelete) {
+        await strapi.documents(`plugin::${PLUGIN_ID}.email-for-notifications`).delete({ documentId: docToDelete.documentId });
+      }
+
+      return { success: true };
+    } catch (err: any) {
+      return { success: false, err };
+    }
+  }
+});
+
+export default notificationsService;

--- a/types/Config.ts
+++ b/types/Config.ts
@@ -6,8 +6,9 @@ export default interface Config {
   githubToken: string;
   environment: string;
   hideGithubLink?: boolean;
+  enableEmailNotifications?: boolean;
   staging?: {
     workflowID: string;
     branch?: string;
-  }
+  },
 }


### PR DESCRIPTION
- Add page to manage list of email addresses that will receive email notifications
- Add CollectionType to keep track of above mentioned email list
- Add optional `enableEmailNotifications` field to the plugin's config
- Trigger notifications on workflow trigger