### PR TITLE
Add API endpoint meant to send notifications upon a workflow's end

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Appropriate documentation will come with version 1.0.0.
 - **Optional:** Implement toasts for user feedback (although alerts are kinda nice because they force you to read and click to dismiss them) ✅
 - Generalize the `environment` parameter to an `inputs` array and allow users to configure whether they want to filter deployment history by any of them
 - Add email notifications on workflow trigger ✅
-- Add email notifications on workflow completion
+- Add email notifications on workflow completion ✅
 - Documentation + Release 1.0.0 + Submit plugin to Strapi Market
 
 ### Possible further enhancements
@@ -26,6 +26,7 @@ Appropriate documentation will come with version 1.0.0.
 - Allow multiple workflows
 - Add the option to include a mandatory staging workflow before any workflow ✅
 - Allow configuration of specific content types list to monitor for updates when determining staging status (currently disables production deployment after ANY publish action)
+- Expand email notification API endpoint (for workflow end) to be able to notify of workflow result directly inside the email
 - Allow customization of the email notifications' content through templates in configuration
 - Split each email notification trigger (staging trigger, prod trigger, staging workflow end, prod workflow end) to allow for finer configuration
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-static-deploy",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Trigger Github workflows to build and deploy statically generated websites",
   "license": "MIT",
   "strapi": {

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -4,13 +4,19 @@ type Validator = Partial<Config>;
 
 export default {
   default: {},
-  validator({ owner, repo, branch, workflowID, githubToken, environment, staging, enableEmailNotifications }: Validator) {
+  validator({ owner, repo, branch, workflowID, githubToken, environment, staging, notifications }: Validator) {
     // Check if required keys are present
     if (!(owner && repo && branch && workflowID && githubToken)) {
       throw new Error('`owner`, `repo`, `branch`, `workflowID` and `githubToken` keys in your plugin config are required');
     }
     if (staging && !staging.workflowID) {
       throw new Error('`staging.workflowID` key in your plugin config is missing, either set it to a string or remove the whole staging object');
+    }
+    if (notifications && notifications.enabled === undefined) {
+      throw new Error('`notifications.enabled` key in your plugin config is missing, either set it to a string or remove the whole notifications object');
+    }
+    if (notifications && !notifications.bearerToken) {
+      throw new Error('`notifications.bearerToken` key in your plugin config is missing, either set it to a string or remove the whole notifications object');
     }
 
     // Check if base config is valid
@@ -39,6 +45,14 @@ export default {
     }
     if (staging && staging.branch && typeof staging.branch !== 'string') {
       throw new Error('`staging.githubToken` key in your plugin config has to be a string');
+    }
+
+    // Check if notifications config is valid
+    if (notifications && typeof notifications.enabled !== 'boolean') {
+      throw new Error('`notifications.enabled` key in your plugin config has to be a boolean');
+    }
+    if (notifications && typeof notifications.bearerToken !== 'string') {
+      throw new Error('`notifications.bearerToken` key in your plugin config has to be a string');
     }
   },
 };

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -25,6 +25,6 @@ export default {
   routes,
   services,
   contentTypes,
-  // policies,
+  policies,
   // middlewares,
 };

--- a/server/src/policies/checkBearerToken.ts
+++ b/server/src/policies/checkBearerToken.ts
@@ -1,0 +1,21 @@
+import { PLUGIN_ID } from "../../../admin/src/pluginId";
+import Config from "../../../types/Config";
+
+export default (policyContext, config, { strapi }) => {
+  const notifications: Config['notifications'] = strapi.plugin(PLUGIN_ID).config('notifications');
+  if (!notifications || !notifications.enabled) {
+    return false;
+  }
+
+  const authHeader = policyContext.request.header.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return false;
+  }
+
+  const token = authHeader.replace('Bearer ', '');
+  if (token !== notifications.bearerToken) {
+    return false;
+  }
+
+  return true;
+};

--- a/server/src/policies/checkWorkflowEndEvent.ts
+++ b/server/src/policies/checkWorkflowEndEvent.ts
@@ -1,0 +1,8 @@
+export default (policyContext, config, { strapi }) => {
+  const { event } = policyContext.request.body;
+  if (!event || !['staging-end', 'prod-end', 'end'].includes(event)) {
+    return false;
+  }
+
+  return true;
+};

--- a/server/src/policies/index.ts
+++ b/server/src/policies/index.ts
@@ -1,1 +1,7 @@
-export default {};
+import checkBearerToken from './checkBearerToken';
+import checkWorkflowEndEvent from './checkWorkflowEndEvent';
+
+export default {
+  hasValidBearerToken: checkBearerToken,
+  isValidWorkflowEndNotificationEvent: checkWorkflowEndEvent,
+};

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -1,3 +1,5 @@
+import { PLUGIN_ID } from "../../../admin/src/pluginId";
+
 export default {
   type: 'admin',
   routes: [
@@ -81,5 +83,17 @@ export default {
         policies: ['admin::isAuthenticatedAdmin'],
       },
     },
+    {
+      method: 'POST',
+      path: '/notify-workflow-end',
+      handler: 'notifications.send',
+      config: {
+        auth: false,
+        policies: [
+          `plugin::${PLUGIN_ID}.hasValidBearerToken`,
+          `plugin::${PLUGIN_ID}.isValidWorkflowEndNotificationEvent`,
+        ],
+      },
+    }
   ],
 };

--- a/server/src/services/config.ts
+++ b/server/src/services/config.ts
@@ -11,8 +11,8 @@ const configService = ({ strapi }: { strapi: Core.Strapi }) => ({
       const githubToken = strapi.plugin(PLUGIN_ID).config('githubToken');
       const environment = strapi.plugin(PLUGIN_ID).config('environment'); // TODO: Generalize this to inputs to be able to add any input
       const hideGithubLink = strapi.plugin(PLUGIN_ID).config('hideGithubLink');
-      const enableEmailNotifications = strapi.plugin(PLUGIN_ID).config('enableEmailNotifications');
       const staging = strapi.plugin(PLUGIN_ID).config('staging');
+      const notifications = strapi.plugin(PLUGIN_ID).config('notifications');
 
       return {
         owner,
@@ -22,8 +22,8 @@ const configService = ({ strapi }: { strapi: Core.Strapi }) => ({
         githubToken,
         environment,
         hideGithubLink,
-        enableEmailNotifications,
         staging,
+        notifications,
       };
     } catch (err: any) {
       return err.response;

--- a/server/src/services/githubActions.ts
+++ b/server/src/services/githubActions.ts
@@ -114,18 +114,22 @@ const githubActionsService = ({ strapi }: { strapi: Core.Strapi }) => ({
       // The following is an array of bools that maps whether or not each workflow belongs to the current environment
       const environmentHistory: ReadonlyArray<boolean> = await Promise.all(
         history.map(async (workflow: { readonly jobs_url: string }) => {
-          const jobs = await axios.get(workflow.jobs_url, {
-            headers: {
-              Accept: 'application/vnd.github+json',
-              Authorization: `token ${githubToken}`,
-            },
-          });
+          try {
+            const jobs = await axios.get(workflow.jobs_url, {
+              headers: {
+                Accept: 'application/vnd.github+json',
+                Authorization: `token ${githubToken}`,
+              },
+            });
 
-          return (
-            jobs.data.jobs.find((job: { readonly name: string }) =>
-              job.name.includes(environment as string)
-            ) !== undefined
-          );
+            return (
+              jobs.data.jobs.find((job: { readonly name: string }) =>
+                job.name.includes(environment as string)
+              ) !== undefined
+            );
+          } catch {
+            return false;
+          }
         })
       );
 

--- a/types/Config.ts
+++ b/types/Config.ts
@@ -6,9 +6,12 @@ export default interface Config {
   githubToken: string;
   environment: string;
   hideGithubLink?: boolean;
-  enableEmailNotifications?: boolean;
   staging?: {
     workflowID: string;
     branch?: string;
-  },
+  };
+  notifications?: {
+    enabled: boolean;
+    bearerToken: string;
+  };
 }


### PR DESCRIPTION
- Remove `enableEmailNotifications` field from config
- Add optional `notifications` object to config
- Add `enabled` field to `notifications` config object
- Add `bearerToken` field (used for newly added endpoint) to `notifications` config object
- Prevent an error in fetching one workflow's jobs from breaking the whole history fetch
- Add API endpoint meant to send notifications upon a workflow's end