### PR TITLE
Await email send

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-static-deploy",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Trigger Github workflows to build and deploy statically generated websites",
   "license": "MIT",
   "strapi": {

--- a/server/src/services/notifications.ts
+++ b/server/src/services/notifications.ts
@@ -39,7 +39,7 @@ const notificationsService = ({ strapi }: { strapi: Core.Strapi }) => ({
       const emails = (await strapi.documents(`plugin::${PLUGIN_ID}.email-for-notifications`).findMany({ sort: 'email:asc' })).map(doc => doc.email);
 
       if (emails.length > 0) {
-        strapi.plugin('email').services.email.send({
+        await strapi.plugin('email').services.email.send({
             to: emails.join(','),
             subject: notificationTitle[event],
             html: notificationBody((event === 'staging-trigger' || event === 'staging-end') ? (staging?.workflowID ?? '') : workflowID, url)[event],
@@ -48,7 +48,7 @@ const notificationsService = ({ strapi }: { strapi: Core.Strapi }) => ({
       
       return { enabled: true, success: true };
     } catch (err: any) {
-      return err.response;
+      return { success: false, err };
     }
   },
   async getEmails() {


### PR DESCRIPTION
Add `await` when calling `strapi.plugin('email').services.email.send()`

Without this the service returns success when the above mentioned function throws an error

We can now correctly wait for the function to resolve before returning it result