### PR TITLE
Use array instead of comma-separated string for notification email recipients

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-static-deploy",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Trigger Github workflows to build and deploy statically generated websites",
   "license": "MIT",
   "strapi": {

--- a/server/src/services/notifications.ts
+++ b/server/src/services/notifications.ts
@@ -40,9 +40,9 @@ const notificationsService = ({ strapi }: { strapi: Core.Strapi }) => ({
 
       if (emails.length > 0) {
         await strapi.plugin('email').services.email.send({
-            to: emails.join(','),
-            subject: notificationTitle[event],
-            html: notificationBody((event === 'staging-trigger' || event === 'staging-end') ? (staging?.workflowID ?? '') : workflowID, url)[event],
+          to: emails,
+          subject: notificationTitle[event],
+          html: notificationBody((event === 'staging-trigger' || event === 'staging-end') ? (staging?.workflowID ?? '') : workflowID, url)[event],
         });
       }
       


### PR DESCRIPTION
Ensures compatibility with Amazon SES